### PR TITLE
Fix install checking when installed from UnityHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# unity-installer
+# Unity Installer
 Go implementation of Unity Hub's downloader and installer - designed for use in continuous integration.
+
+# Installing
+1. Download `unity-installer`
+    - Windows: [unity-installer.exe](https://github.com/wellplayedgames/unity-installer/releases/latest/download/unity-installer.exe)
+    - Linux: [unity-installer-linux-amd64](https://github.com/wellplayedgames/unity-installer/releases/latest/download/unity-installer-linux-amd64)
+    - macOS: [unity-installer-darwin-amd64](https://github.com/wellplayedgames/unity-installer/releases/latest/download/unity-installer-darwin-amd64)
+2. Rename this to unity-installer if not on Windows and put it in the client Unity project
+3. This may need making executable using `chmod +x unity-installer` 
+
+# Building
+This requires to be built for all platforms. In `cmd/unity-installer` on windows:
+```
+# Windows
+go build .
+
+# Linux
+env GOOS=linux GOARCH=amd64 go build .
+mv unity-installer unity-installer-linux-amd64
+
+# Darwin (mac)
+env GOOS=darwin GOARCH=amd64 go build .
+mv unity-installer unity-installer-darwin-amd64
+```
+
+# Usage
+
+## Install version set in project
+Example setup for a project running on windows setup.
+* Tools installed in platform folders in the `Scripts` folder at the root:
+  * `Scripts/Darwin/unity-installer`
+  * `Scripts/Linux/unity-installer`
+  * `Scripts/Windows/unity-installer.exe`
+* In the root directory:
+  ```
+  ./Scripts/Windows/unity-installer.exe --install-path="C:\Unity" install --for-project=Client
+  ```
+  **NOTE:** The install path for unity should be set the same in UnityHub installs can be shared

--- a/pkg/release/releases.go
+++ b/pkg/release/releases.go
@@ -43,7 +43,9 @@ type Package struct {
 	Version        string `json:"version"`
 	DownloadURL    string `json:"downloadUrl"`
 	DownloadSize   int64  `json:"downloadSize"`
-	InstalledSize  int64  `json:"installedSize"`
+	// This has been removed as it was found to contain floats when installed
+	// from UnityHub which causes it to fail
+	// InstalledSize  int64  `json:"installedSize"`
 }
 
 // ModuleRelease represents an optional Unity module tied to a specific editor


### PR DESCRIPTION
Seems that UnityHub may have issues with sanitising its own data so the `installedSize` for a package would sometimes be a float:
```
   "downloadSize": 291803386,
   "installedSize": 595278907.44,
```
which would throw an error parsing it to an int64.

As its not used, we can just not read it and continue on.

Additional documentation has been added to help improve usage